### PR TITLE
RxResult loader fix

### DIFF
--- a/PopularMovies/app/src/main/java/arturvasilov/udacity/nanodegree/popularmovies/rx/RxResultLoader.java
+++ b/PopularMovies/app/src/main/java/arturvasilov/udacity/nanodegree/popularmovies/rx/RxResultLoader.java
@@ -39,6 +39,8 @@ class RxResultLoader<T> extends Loader<RxResult<T>> {
     protected void onStartLoading() {
         if (takeContentChanged() || mResult == null) {
             forceLoad();
+        }else {
+            super.deliverResult(RxResult.onNext(mResult));
         }
     }
 


### PR DESCRIPTION
RxResultLoader loader don't return obtained result in init method. If data was received before it will not be returned.
